### PR TITLE
Added min height to closet details css in ClosetDetails and ManageClo…

### DIFF
--- a/src/components/closet_items/ClosetDetails.vue
+++ b/src/components/closet_items/ClosetDetails.vue
@@ -36,6 +36,7 @@ export default {
 @import '@/styles/_colors.scss';
 
 .closet-details {
+    min-height: 12rem;
     max-height: calc(100% - 1.54rem);
     background-color: $primary-color;
     overflow: auto;

--- a/src/components/manage_items/ManageClosetDetails.vue
+++ b/src/components/manage_items/ManageClosetDetails.vue
@@ -56,6 +56,7 @@ export default {
 @import '@/styles/_colors.scss';
 
 .closet-details {
+    min-height: 12rem;
     max-height: calc(100% - 1.54rem);
     background-color: $primary-color;
     overflow: auto;


### PR DESCRIPTION
…setDetails components. This was because if there was nothing present in the tab, the tabs would stay but the closet position would disappear unless clicked on the other tab. Min height is according the regular 1 card length.